### PR TITLE
Implements subpagination for ddgr

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -1332,6 +1332,8 @@ class DdgCmd(object):
             if self.index >= 0:
                 self.display_results()
             else:
+                # Set index to negative the pagination value, so that
+                # if do_next is called, index will begin at 0.
                 self.index = -self.options.pagination
                 print("Already at the earliest results", file=sys.stderr)
             return

--- a/ddgr
+++ b/ddgr
@@ -1574,7 +1574,7 @@ def parse_args(args=None, namespace=None):
            '[d (1 day), w (1 week), m (1 month)]')
     addarg('-w', '--site', dest='sites', action='append', metavar='SITE', help='search sites using DuckDuckGo')
     addarg('-x', '--expand', action='store_true', help='Show complete url in search results')
-    addarg('-n', '--num', dest='pagination', type=int)
+    addarg('-n', '--num', dest='pagination', type=int, default=10)
     addarg('-p', '--proxy', help='tunnel traffic through an HTTPS proxy in the form [http[s]://][user:pwd@]host[:port]')
     addarg('--unsafe', action='store_true', help='disable safe search')
     addarg('--noua', action='store_true', help='disable user agent')

--- a/ddgr
+++ b/ddgr
@@ -1404,7 +1404,6 @@ class DdgCmd(object):
                 elif cmd == '?':
                     self.help()
                 elif pag and cmd.isdigit() and int(cmd) in range(1, pag+1):
-                    print(cmd)
                     i = int(cmd) + self.index
                     open_url(self._urltable[str(i)])
                 elif cmd in self._urltable:

--- a/ddgr
+++ b/ddgr
@@ -1276,6 +1276,7 @@ class DdgCmd(object):
         if self.options.pagination:
             self.index = 0
             self.results = []
+            self._urltable = {}
         # Update keywords and reconstruct URL
         self._opts.keywords = arg
         self._ddg_url = DdgUrl(self._opts)
@@ -1380,6 +1381,8 @@ class DdgCmd(object):
             # change behaviour of the prompt. However, we have already
             # laid a lot of ground work for the dispatcher, e.g., the
             # `no_argument' decorator.
+
+            pag = self.options.pagination
             try:
                 cmd = self.cmd
                 if cmd == 'f':
@@ -1400,7 +1403,8 @@ class DdgCmd(object):
                     break
                 elif cmd == '?':
                     self.help()
-                elif self.options.pagination and int(cmd) in range(1, self.options.pagination+1):
+                elif pag and cmd.isdigit() and int(cmd) in range(1, pag+1):
+                    print(cmd)
                     i = int(cmd) + self.index
                     open_url(self._urltable[str(i)])
                 elif cmd in self._urltable:

--- a/ddgr
+++ b/ddgr
@@ -989,9 +989,10 @@ class Result(object):
         if colors:
             print(colors.reset, end='')
 
-    def print(self):
+    def print(self, display_index):
         """Print the result entry."""
-        self._print_title_and_url(self.index, self.title, self.url)
+
+        self._print_title_and_url(display_index, self.title, self.url)
         self._print_metadata_and_abstract(self.abstract, metadata=self.metadata)
 
     def jsonizable_object(self):
@@ -1138,20 +1139,24 @@ class DdgCmd(object):
 
         parser = DdgParser()
         parser.feed(page.text)
+
         if self.options.pagination:
             self.results.extend(parser.results)
+            offset = len(self._urltable)
+            for r in self.results:
+                for k, v in r.urltable().items():
+                    i = str(int(k) + offset)
+                    self._urltable.update({i: v})
         else:
+            self._urltable = {}
             self.results = parser.results
+            for r in self.results:
+                self._urltable.update(r.urltable())
 
         self._ddg_url._nextParams_prev = parser.nextParams_prevbtn
         self._ddg_url._nextParams_next = parser.nextParams_nextbtn
         logdbg('Prev nextParams: %s', self._ddg_url._nextParams_prev)
         logdbg('Next nextParams: %s', self._ddg_url._nextParams_next)
-
-        self._urltable = {}
-
-        for r in self.results:
-            self._urltable.update(r.urltable())
 
         self._ddg_url.update_num(len(parser.results))
 
@@ -1181,8 +1186,8 @@ class DdgCmd(object):
                 print('No results.', file=sys.stderr)
             else:
                 sys.stderr.write(prelude)
-                for r in results:
-                    r.print()
+                for i, r in enumerate(results):
+                    r.print(str(i+1))
 
     @require_keywords
     def fetch_and_display(self, prelude='\n', json_output=False):
@@ -1308,10 +1313,16 @@ class DdgCmd(object):
                 for key, value in sorted(self._urltable.items()):
                     open_url(self._urltable[key])
             elif nav in self._urltable:
+                if self.options.pagination:
+                    nav = str(int(nav) + self.index)
                 open_url(self._urltable[nav])
             elif '-' in nav:
                 try:
-                    vals = [int(x) for x in nav.split('-')]
+                    if self.options.pagination:
+                        vals = [int(x) + self.index for x in nav.split('-')]
+                    else:
+                        vals = [int(x) for x in nav.split('-')]
+
                     if (len(vals) != 2):
                         printerr('Invalid range %s.' % nav)
                         continue
@@ -1389,6 +1400,9 @@ class DdgCmd(object):
                     break
                 elif cmd == '?':
                     self.help()
+                elif self.options.pagination and int(cmd) in range(1, self.options.pagination+1):
+                    i = int(cmd) + self.index
+                    open_url(self._urltable[str(i)])
                 elif cmd in self._urltable:
                     open_url(self._urltable[cmd])
                 elif self.keywords and cmd.isdigit() and int(cmd) < 100:

--- a/ddgr
+++ b/ddgr
@@ -1254,6 +1254,11 @@ class DdgCmd(object):
     @require_keywords
     @no_argument
     def do_first(self):
+        if self.options.pagination:
+            self.index = 0
+            self.display_results()
+            return
+
         try:
             self._ddg_url.first_page()
         except ValueError as e:

--- a/ddgr
+++ b/ddgr
@@ -1263,7 +1263,9 @@ class DdgCmd(object):
         self.fetch_and_display()
 
     def do_ddg(self, arg):
-        self.__init__(self._opts)
+        if self.options.pagination:
+            self.index = 0
+            self.results = []
         # Update keywords and reconstruct URL
         self._opts.keywords = arg
         self._ddg_url = DdgUrl(self._opts)

--- a/ddgr
+++ b/ddgr
@@ -1087,7 +1087,7 @@ class DdgCmd(object):
 
     def __init__(self, opts):
         super().__init__()
-        self.index =0
+        self.index = 0
         self._opts = opts
 
         self._ddg_url = DdgUrl(opts)
@@ -1171,20 +1171,15 @@ class DdgCmd(object):
             print(json.dumps(results_object, indent=2, sort_keys=True, ensure_ascii=False))
         else:
             # Regular output
-            if not self.results:
+            if not self.results or self.index > len(self.results):
                 print('No results.', file=sys.stderr)
             else:
                 sys.stderr.write(prelude)
-                pag = self.options.pagination
 
+                pag = self.options.pagination
                 if pag:
                     for r in self.results[self.index:self.index+pag]:
                         r.print()
-
-                    if self.index + pag > len(self.results):
-                        self.index = len(self.results)
-                    else:
-                        self.index += pag
                 else:
                     for r in self.results:
                         r.print()
@@ -1282,10 +1277,15 @@ class DdgCmd(object):
     @no_argument
     def do_next(self):
         # If no results were fetched last time, we have hit the last page already
-        if self._ddg_url._qrycnt == 0:
+        if self._ddg_url._qrycnt == 0 and self.index >= len(self.results):
             print('No results.', file=sys.stderr)
-        elif self.options.pagination and self.index < len(self.results):
-            self.display_results()
+        elif self.options.pagination:
+            self.index += self.options.pagination
+            if len(self.results) - self.index < self.options.pagination:
+                self._ddg_url.next_page()
+                self.fetch_and_display()
+            else:
+                self.display_results()
         else:
             self._ddg_url.next_page()
             self.fetch_and_display()
@@ -1326,10 +1326,13 @@ class DdgCmd(object):
     @no_argument
     def do_previous(self):
         if self.options.pagination:
-            self.index -= (self.options.pagination * 2)
+            self.index -= self.options.pagination
             if self.index >= 0:
                 self.display_results()
-                return
+            else:
+                self.index = -self.options.pagination
+                print("Already at the earliest results", file=sys.stderr)
+            return
 
         try:
             self._ddg_url.prev_page()

--- a/ddgr
+++ b/ddgr
@@ -1087,7 +1087,7 @@ class DdgCmd(object):
 
     def __init__(self, opts):
         super().__init__()
-
+        self.index =0
         self._opts = opts
 
         self._ddg_url = DdgUrl(opts)
@@ -1138,8 +1138,11 @@ class DdgCmd(object):
 
         parser = DdgParser()
         parser.feed(page.text)
+        if self.options.pagination:
+            self.results.extend(parser.results)
+        else:
+            self.results = parser.results
 
-        self.results = parser.results
         self._ddg_url._nextParams_prev = parser.nextParams_prevbtn
         self._ddg_url._nextParams_next = parser.nextParams_nextbtn
         logdbg('Prev nextParams: %s', self._ddg_url._nextParams_prev)
@@ -1150,7 +1153,7 @@ class DdgCmd(object):
         for r in self.results:
             self._urltable.update(r.urltable())
 
-        self._ddg_url.update_num(len(self.results))
+        self._ddg_url.update_num(len(parser.results))
 
     @require_keywords
     def display_results(self, prelude='\n', json_output=False):
@@ -1172,8 +1175,19 @@ class DdgCmd(object):
                 print('No results.', file=sys.stderr)
             else:
                 sys.stderr.write(prelude)
-                for r in self.results:
-                    r.print()
+                pag = self.options.pagination
+
+                if pag:
+                    for r in self.results[self.index:self.index+pag]:
+                        r.print()
+
+                    if self.index + pag > len(self.results):
+                        self.index = len(self.results)
+                    else:
+                        self.index += pag
+                else:
+                    for r in self.results:
+                        r.print()
 
     @require_keywords
     def fetch_and_display(self, prelude='\n', json_output=False):
@@ -1254,6 +1268,7 @@ class DdgCmd(object):
         self.fetch_and_display()
 
     def do_ddg(self, arg):
+        self.__init__(self._opts)
         # Update keywords and reconstruct URL
         self._opts.keywords = arg
         self._ddg_url = DdgUrl(self._opts)
@@ -1269,6 +1284,8 @@ class DdgCmd(object):
         # If no results were fetched last time, we have hit the last page already
         if self._ddg_url._qrycnt == 0:
             print('No results.', file=sys.stderr)
+        elif self.options.pagination and self.index < len(self.results):
+            self.display_results()
         else:
             self._ddg_url.next_page()
             self.fetch_and_display()
@@ -1308,6 +1325,12 @@ class DdgCmd(object):
     @require_keywords
     @no_argument
     def do_previous(self):
+        if self.options.pagination:
+            self.index -= (self.options.pagination * 2)
+            if self.index >= 0:
+                self.display_results()
+                return
+
         try:
             self._ddg_url.prev_page()
         except ValueError as e:
@@ -1525,6 +1548,7 @@ def parse_args(args=None, namespace=None):
            '[d (1 day), w (1 week), m (1 month)]')
     addarg('-w', '--site', dest='sites', action='append', metavar='SITE', help='search sites using DuckDuckGo')
     addarg('-x', '--expand', action='store_true', help='Show complete url in search results')
+    addarg('-n', '--num', dest='pagination', type=int)
     addarg('-p', '--proxy', help='tunnel traffic through an HTTPS proxy in the form [http[s]://][user:pwd@]host[:port]')
     addarg('--unsafe', action='store_true', help='disable safe search')
     addarg('--noua', action='store_true', help='disable user agent')

--- a/ddgr
+++ b/ddgr
@@ -1164,10 +1164,16 @@ class DdgCmd(object):
         See `fetch_and_display`.
 
         """
+
+        if self.options.pagination:
+            results = self.results[self.index:self.index+self.options.pagination]
+        else:
+            results = self.results
+
         if json_output:
             # JSON output
             import json
-            results_object = [r.jsonizable_object() for r in self.results]
+            results_object = [r.jsonizable_object() for r in results]
             print(json.dumps(results_object, indent=2, sort_keys=True, ensure_ascii=False))
         else:
             # Regular output
@@ -1175,14 +1181,8 @@ class DdgCmd(object):
                 print('No results.', file=sys.stderr)
             else:
                 sys.stderr.write(prelude)
-
-                pag = self.options.pagination
-                if pag:
-                    for r in self.results[self.index:self.index+pag]:
-                        r.print()
-                else:
-                    for r in self.results:
-                        r.print()
+                for r in results:
+                    r.print()
 
     @require_keywords
     def fetch_and_display(self, prelude='\n', json_output=False):


### PR DESCRIPTION
Here's a provisional implementation of subpagination for ddgr. 

Pagination is set by using the `-n` (or `--num`) option which takes an integer N to paginate the results by. For example: `ddgr python -n 5` will paginate by 5 results at a time.

If the number of fetched results left to display is less than the pagination value, new results from the next Ddg results page are fetched and appended to the list of results already returned. Use of the `p` command in the omniprompt will show the previous N results, where N is the pagination value.

If the `f` command is used in the omni prompt, the index is reset to 0 so that the first set of results are displayed.

Please let me know if this is in line with what you are thinking/what changes should be made.