### PR TITLE
Allow better customization of installation directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,25 @@
 PREFIX ?= /usr/local
-BINDIR = $(DESTDIR)$(PREFIX)/bin
-MANDIR = $(DESTDIR)$(PREFIX)/share/man/man1
-DOCDIR = $(DESTDIR)$(PREFIX)/share/doc/ddgr
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man/man1
+DOCDIR ?= $(PREFIX)/share/doc/ddgr
 
 .PHONY: all install uninstall
 
 all:
 
 install:
-	install -m755 -d $(BINDIR)
-	install -m755 -d $(MANDIR)
-	install -m755 -d $(DOCDIR)
+	install -m755 -d $(DESTDIR)$(BINDIR)
+	install -m755 -d $(DESTDIR)$(MANDIR)
+	install -m755 -d $(DESTDIR)$(DOCDIR)
 	gzip -c ddgr.1 > ddgr.1.gz
-	install -m755 ddgr $(BINDIR)
-	install -m644 ddgr.1.gz $(MANDIR)
-	install -m644 README.md $(DOCDIR)
+	install -m755 ddgr $(DESTDIR)$(BINDIR)
+	install -m644 ddgr.1.gz $(DESTDIR)$(MANDIR)
+	install -m644 README.md $(DESTDIR)$(DOCDIR)
 	rm -f ddgr.1.gz
 
 uninstall:
-	rm -f $(BINDIR)/ddgr
-	rm -f $(MANDIR)/ddgr.1.gz
-	rm -rf $(DOCDIR)
+	rm -f $(DESTDIR)$(BINDIR)/ddgr
+	rm -f $(DESTDIR)$(MANDIR)/ddgr.1.gz
+	rm -rf $(DESTDIR)$(DOCDIR)
 
 test: ;


### PR DESCRIPTION
For instance, FreeBSD needs `MANDIR = ${PREFIX}/man/man1`