### PR TITLE
Add closing parenthese in zsh completion

### DIFF
--- a/auto-completion/zsh/_ddgr
+++ b/auto-completion/zsh/_ddgr
@@ -40,7 +40,7 @@ args=(
     '(-C --nocolor)'{-C,--nocolor}'[disable color output]'
     '(--colors)--colors[set output colors]:six-letter string'
     '(-j --ducky)'{-j,--ducky}'[open the first result in web browser]'
-    '(-t --time'{-t,--time}'[limit search duration]:d/w/m'
+    '(-t --time)'{-t,--time}'[limit search duration]:d/w/m'
     '(-w --site)'{-w,--site}'[search a site using DuckDuckGo]:domain'
     '(-x --expand)'{-x,--expand}'[show complete URL in results]'
     '(-p --proxy)'{-p,--proxy}'[specify proxy]:[http[s]://][user:pwd@]host[:port]'


### PR DESCRIPTION
As found in NixOS/nixpkgs#32222 by @mic92