### PR TITLE
Add support for snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,7 @@ apps:
 parts:
   ddgr:
     plugin: make
-    source: https://github.com/jarun/ddgr.git
+    source: .
     stage-packages:
       - python3
       - python3-requests

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,84 @@
+name: ddgr
+version: git
+summary: DuckDuckGo from the terminal
+description: |
+  ddgr is a cmdline utility to search DuckDuckGo from the terminal. While 
+  googler is highly popular among cmdline users, in many forums the need 
+  of a similar utility for privacy-aware DuckDuckGo came up. DuckDuckGo 
+  Bangs are super-cool too! So here's ddgr for you!
+  Unlike the web interface, you can specify the number of search results 
+  you would like to see per page. It's more convenient than skimming through 
+  30-odd search results per page. The default interface is carefully designed 
+  to use minimum space without sacrificing readability.
+  ddgr isn't affiliated to DuckDuckGo in any way..
+
+grade: stable
+confinement: strict
+
+apps:
+  ddgr:
+    environment:
+      LC_ALL: "C.UTF-8"
+    command: usr/local/bin/ddgr
+    plugs:
+      - network
+      - desktop
+
+parts:
+  ddgr:
+    plugin: make
+    source: https://github.com/jarun/ddgr.git
+    stage-packages:
+      - python3
+      - python3-requests
+    filesets:
+      cruft_compilers_and_debuggers:
+        - -usr/bin/pdb3*
+      cruft_debhelper:
+        - -usr/bin/dh_*
+        - -usr/share/debhelper
+        - -usr/share/dh-python
+        - -usr/share/perl5/Debian
+      cruft_docs:
+        - -usr/share/doc
+        - -usr/share/doc-base
+      cruft_lintian:
+        - -usr/share/lintian/overrides
+      cruft_man_pages:
+        - -usr/share/man
+        - -share/man
+      cruft_meta:
+        - -usr/share/applications
+        - -usr/share/pixmaps
+      cruft_python_2to3:
+        - -usr/bin/2to3*
+        - -usr/lib/python*/lib2to3
+      cruft_python_idle:
+        - -usr/lib/python*/idlelib
+        - -usr/lib/python*/tkinter
+      cruft_python_pip:
+        - -lib/python*/site-packages/pip
+      cruft_python_setuptools:
+        - -lib/python*/site-packages/setuptools*
+      cruft_python_tests:
+        - -lib/python*/site-packages/tests
+      cruft_python_venv:
+        - -usr/lib/python*/venv
+      cruft_python_wheel:
+        - -lib/python*/site-packages/wheel*
+      cruft_x11:
+        - -usr/share/X11/XErrorDB
+    prime:
+      - $cruft_compilers_and_debuggers
+      - $cruft_debhelper
+      - $cruft_docs
+      - $cruft_lintian
+      - $cruft_man_pages
+      - $cruft_python_2to3
+      - $cruft_python_idle
+      - $cruft_python_pip
+      - $cruft_python_setuptools
+      - $cruft_python_tests
+      - $cruft_python_venv
+      - $cruft_python_wheel
+      - $cruft_x11


### PR DESCRIPTION
This pull request adds support to build ddgr as a snap.

ddgr is already [available](https://snapcraft.io/ddgr/) in the snap store via the yaml in the [snapcrafter](https://github.com/snapcrafters/ddgr).

This PR is to upstream the snapcraft.yaml which creates the snap which is in the store. If the PR is accepted, we can transfer ownership of the ddgr snap to you, the upstream developer. Once done you could use the free build.snapcraft.io service to automatically build new releases of ddgr and push directly to the store. Alternatively you could use travis.

If accepted, I'm happy to walk you through the next steps. 