### PR TITLE
Add copy support using pyperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Unlike the web interface, you can specify the number of search results you would
 
 Note: v1.1 and below require the Python3 `requests` library to make HTTPS requests. This dependency is removed in the later releases.
 
+For clipboard copy support, install [`pyperclip`](https://pypi.python.org/pypi/pyperclip) from `pip`.
+
 #### From a package manager
 
 - [AUR](https://aur.archlinux.org/packages/ddgr/)

--- a/ddgr
+++ b/ddgr
@@ -1487,6 +1487,7 @@ class DdgArgumentParser(argparse.ArgumentParser):
           d keywords            new DDG search for 'keywords' with original options
                                 should be used to search omniprompt keys and indices
           x                     toggle url expansion
+          c <index>             copy url to clipboard
           q, ^D, double Enter   exit ddgr
           ?                     show omniprompt help
           *                     other inputs are considered as new search keywords

--- a/ddgr
+++ b/ddgr
@@ -23,7 +23,6 @@ import html.entities
 import html.parser
 import logging
 import os
-import pyperclip
 import signal
 import subprocess
 import sys
@@ -35,6 +34,11 @@ import webbrowser
 
 try:
     import readline
+except ImportError:
+    pass
+
+try:
+    import pyperclip
 except ImportError:
     pass
 
@@ -173,11 +177,6 @@ def printerr(msg):
     ``msg`` could be any stringifiable value.
     """
     print(msg, file=sys.stderr)
-
-
-def copy_url(url):
-    """Copy url to system clipboard using pyperclip."""
-    pyperclip.copy(url)
 
 
 # Classes
@@ -1463,8 +1462,12 @@ class DdgCmd(object):
                     printerr('url expansion toggled.')
                 elif cmd[0] == 'c' and cmd[2:].isdigit():
                     url = self._urltable[cmd[2:]]
-                    printerr('copied url: {}'.format(url))
-                    copy_url(url)
+                    try:
+                        pyperclip.copy(url)
+                    except NameError:
+                        printerr("cannot copy url: pyperclip not installed")
+                    else:
+                        printerr('copied url: {}'.format(url))
                 else:
                     self.do_ddg(cmd)
             except NoKeywordsException:
@@ -1487,7 +1490,7 @@ class DdgArgumentParser(argparse.ArgumentParser):
           d keywords            new DDG search for 'keywords' with original options
                                 should be used to search omniprompt keys and indices
           x                     toggle url expansion
-          c <index>             copy url to clipboard
+          c <index>             copy url to clipboard (needs pyperclip)
           q, ^D, double Enter   exit ddgr
           ?                     show omniprompt help
           *                     other inputs are considered as new search keywords

--- a/ddgr
+++ b/ddgr
@@ -23,6 +23,7 @@ import html.entities
 import html.parser
 import logging
 import os
+import pyperclip
 import signal
 import subprocess
 import sys
@@ -172,6 +173,12 @@ def printerr(msg):
     ``msg`` could be any stringifiable value.
     """
     print(msg, file=sys.stderr)
+
+
+def copy_url(url):
+    """Copy url to system clipboard using pyperclip."""
+    pyperclip.copy(url)
+
 
 # Classes
 
@@ -1454,6 +1461,10 @@ class DdgCmd(object):
                 elif cmd == 'x':
                     Result.urlexpand = not Result.urlexpand
                     printerr('url expansion toggled.')
+                elif cmd[0] == 'c' and cmd[2:].isdigit():
+                    url = self._urltable[cmd[2:]]
+                    printerr('copied url: {}'.format(url))
+                    copy_url(url)
                 else:
                     self.do_ddg(cmd)
             except NoKeywordsException:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pyperclip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyperclip


### PR DESCRIPTION
I know that `ddgr` tries to be dependency-free on Python side of things, but I haven't found a better cross-platform solution than `pyperclip`.

If you know how to implement this without dependencies, please share!