### PR TITLE
Add package for Source Mage

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Note: v1.1 and below require the Python3 `requests` library to make HTTPS reques
 - [openSUSE](https://software.opensuse.org/package/ddgr)
 - [Slackware](http://slackbuilds.org/repository/14.2/network/ddgr/)
 - [Snap Store](https://snapcraft.io/ddgr/) (`sudo snap install ddgr`)
+- [Source Mage](http://codex.sourcemage.org/test/utils/ddgr/) (`cast ddgr`)
 - [Ubuntu](https://packages.ubuntu.com/search?keywords=ddgr&searchon=names&exact=1)
 - [Ubuntu PPA](https://launchpad.net/~twodopeshaggy/+archive/ubuntu/jarun/)
 - [Void Linux](https://github.com/voidlinux/void-packages/tree/master/srcpkgs/ddgr) (`sudo xbps-install -S ddgr`)


### PR DESCRIPTION
This will add ddgr spell for Source Mage as per [this](http://scmweb.sourcemage.org/?p=smgl/grimoire.git;a=commit;h=69957eb9b5e56514950475494d2df284bac451a5).