### PR TITLE
Quote word to be autocompleted (Fix #52)

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -1657,7 +1657,8 @@ def completer_fetch_completions(prefix):
 
     # One can pass the 'hl' query param to specify the language. We
     # ignore that for now.
-    api_url = ('https://duckduckgo.com/ac/?q=%s&kl=wt-wt' % prefix)
+    api_url = ('https://duckduckgo.com/ac/?q=%s&kl=wt-wt' %
+               urllib.parse.quote(prefix, safe=''))
     # A timeout of 3 seconds seems to be overly generous already.
     resp = urllib.request.urlopen(api_url, timeout=3)
     respobj = json.loads(resp.read().decode('utf-8'))


### PR DESCRIPTION
The word to be autocompleted (`prefix`) needs to be quoted, so that the resulting API URL can be correctly encoded in ascii. If the word isn't quoted and contains any non-ascii characters, the http request won't be created. Fixes #52.