### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "./ddgr"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <a href="https://en.wikipedia.org/wiki/Privacy-invasive_software"><img src="https://img.shields.io/badge/privacy-aware-crimson" alt="Privacy Awareness" /></a>
 <a href="https://github.com/jarun/ddgr/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-yellow.svg?maxAge=2592000" alt="License" /></a>
 </p>
+[![Run on Repl.it](https://repl.it/badge/github/jarun/ddgr)](https://repl.it/github/jarun/ddgr)
 
 <p align="center">
 <a href="https://asciinema.org/a/212198"><img src="https://asciinema.org/a/212198.png" alt="Asciicast" width="734"/></a>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://circleci.com/gh/jarun/workflows/ddgr"><img src="https://img.shields.io/circleci/project/github/jarun/ddgr.svg" alt="Build Status" /></a>
 <a href="https://en.wikipedia.org/wiki/Privacy-invasive_software"><img src="https://img.shields.io/badge/privacy-aware-crimson" alt="Privacy Awareness" /></a>
 <a href="https://github.com/jarun/ddgr/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-yellow.svg?maxAge=2592000" alt="License" /></a>
-<a href="https://repl.it/github/jarun/googler"><img src="https://repl.it/badge/github/jarun/googler" alt="Repl.it" /></a>
+<a href="https://repl.it/github/jarun/ddgr"><img src="https://repl.it/badge/github/jarun/ddgr?maxAge=2592000" alt="Repl.it" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <a href="https://circleci.com/gh/jarun/workflows/ddgr"><img src="https://img.shields.io/circleci/project/github/jarun/ddgr.svg" alt="Build Status" /></a>
 <a href="https://en.wikipedia.org/wiki/Privacy-invasive_software"><img src="https://img.shields.io/badge/privacy-aware-crimson" alt="Privacy Awareness" /></a>
 <a href="https://github.com/jarun/ddgr/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-yellow.svg?maxAge=2592000" alt="License" /></a>
+<a href="https://repl.it/github/jarun/googler"><img src="https://repl.it/badge/github/jarun/googler" alt="Repl.it" /></a>
 </p>
-[![Run on Repl.it](https://repl.it/badge/github/jarun/ddgr)](https://repl.it/github/jarun/ddgr)
 
 <p align="center">
 <a href="https://asciinema.org/a/212198"><img src="https://asciinema.org/a/212198.png" alt="Asciicast" width="734"/></a>


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`. This will allow viewers of the repository to click the run on Repl.it button and be able to use ddgr inside the Repl.it environment.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/ddgr).