### PR TITLE
Update .replit to not rely on executable

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "python3"
-run = "./ddgr"
+run = "python ./ddgr"


### PR DESCRIPTION
because repl.it struggles to persist file permissions it's best to just run it as a python script.

Here it is working: cc @Mosrod 

<img width="1564" alt="Screen Shot 2019-12-09 at 10 04 34 PM" src="https://user-images.githubusercontent.com/587518/70500317-1a995e80-1ad0-11ea-910a-868144bcbf3e.png">
