### PR TITLE
Mention brew install in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Note: v1.1 and below require the Python3 `requests` library to make HTTPS reques
 
 Install `ddgr` from your package manager. If the version available is dated try an alternative installation method.
 
+For macOS, install via `brew install ddgr`
+
 <details><summary>Packaging status (expand)</summary>
 <p>
 <br>


### PR DESCRIPTION
README mostly mentions various linux distros.
I had to find in the issues to figure out `brew` is supported. 

I thought it might be better to mention explicitly in README so others aren't confused like I was.