### PR TITLE
Fix backslash in manpage

### DIFF
--- a/ddgr.1
+++ b/ddgr.1
@@ -186,7 +186,7 @@ reverse video prompts
 .TP
 Note that
 .IP - 2
-Bright colors (implemented as \\x1b[90m - \\x1b[97m) may not be available in all color-capable terminal emulators;
+Bright colors (implemented as \ex1b[90m - \ex1b[97m) may not be available in all color-capable terminal emulators;
 .IP - 2
 Some terminal emulators draw bold text in bright colors instead;
 .IP - 2
@@ -231,7 +231,7 @@ DuckDuckGo \fBhello world\fR:
 .EX
 .IP
 .B ddgr !w hello world
-.B ddgr \\\\!w hello world  // bash-specific, need to escape ! on bash
+.B ddgr \e!w hello world  // bash-specific, need to escape ! on bash
 .EE
 .PP
 .IP "" 4
@@ -245,7 +245,7 @@ Bangs work at the omniprompt too. To look up bangs, visit https://duckduckgo.com
 .B alias bang='ddgr --gb --np'
 .IP
 .B bang !w hello world
-.B bang \\\\!w hello world  // bash-specific, need to escape ! on bash
+.B bang \e!w hello world  // bash-specific, need to escape ! on bash
 .EE
 .PP
 .IP 5. 4


### PR DESCRIPTION
According to documentation, to include a literal backslash into the manpage, one has to use `\e`.
For instance, FreeBSD mandoc complains otherwise:

    % mandoc -Tlint -Wunsupp < ddgr.1 
    mandoc: <stdin>:234:2: UNSUPP: unsupported escape sequence: \!
    mandoc: <stdin>:248:2: UNSUPP: unsupported escape sequence: \!