### PR TITLE
fix --complete exception caused due to context manager type error

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -1979,8 +1979,9 @@ def completer_fetch_completions(prefix):
                urllib.parse.quote(prefix, safe=''))
     # A timeout of 3 seconds seems to be overly generous already.
     with urllib.request.urlopen(api_url, timeout=3) as resp:
-        with json.loads(resp.read().decode('utf-8')) as respobj:
-            return [entry['phrase'] for entry in respobj]
+        resptxt = resp.read().decode('utf-8')
+        respobj = json.loads(resptxt)
+        return [entry['phrase'] for entry in respobj]
 
 
 def completer_run(prefix):


### PR DESCRIPTION
This PR solves a TypeError exception that happened on python 3.12.3 when 
running `ddgr --complete blah` on the latest git version. 
It stems from the json.loads returned object (either list or dict) not accepted for the context.

  
```python
  File "/usr/bin/ddgr", line 1982, in completer_fetch_completions
    with json.loads(resp.read().decode('utf-8')) as respobj:
TypeError: 'list' object does not support the context manager protocol
```

Feel free to comment and offer modifications.
