### PR TITLE
Fix --sites using different operator format

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -594,7 +594,10 @@ class DdgUrl:
             else:
                 q += keywords
         if sites:
-            q += ' site:' + ','.join(urllib.parse.quote_plus(site) for site in sites)
+            q += ' ('
+            for site in sites:
+                q += ' site:' + urllib.parse.quote_plus(site) + ' OR'
+            q += ' )'
         qd['q'] = q
 
         return qd


### PR DESCRIPTION
Using a different syntax since the current one (i.e. comma separated list of sites as a value to `site:`) does not seem to work

While this one does: 
`( site:site1.com OR site:site2.com OR ... ) SEARCH_TERM_HERE`

Note: a redundant OR for only a single website does not matter so I did not bother checking for it and removing it. if you feel like it is needed you can ask and I will write it.
