### PR TITLE
Handle URLs containing unicode

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -91,6 +91,7 @@ TEXT_BROWSERS = ['elinks', 'links', 'lynx', 'w3m', 'www-browser']
 
 INDENT = 5
 
+
 # Global helper functions
 def make_safe_url(url: str) -> str:
     """
@@ -127,6 +128,7 @@ def make_safe_url(url: str) -> str:
     fragment = urllib.parse.quote(parts.fragment)
 
     return urllib.parse.urlunsplit((parts.scheme, netloc, path, query, fragment))
+
 
 def open_url(url):
     """Open an URL in the user's default web browser.


### PR DESCRIPTION
Python's webbrowser module can't handle unicode in URLS, it turns every symbol into a question mark.
To be able to open these URLs, escape hostnames with punycode, everything else with percent encoding.

I ran into this issue and decided to fix it.

Issue can be reproduced running a bang query with unicode in it: 

`$ ddgr !w 日本語`

Firefox on MacOS 14.3.1 (23D60) searched duckduckgo with `!w ???`.