### PR TITLE
 change /usr/bin -> /bin for android

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/bin/env python3
 
 # Copyright (C) 2016-2025 Arun Prakash Jana <engineerarun@gmail.com>
 #


### PR DESCRIPTION
remove /usr prefix for android terminals from first line in script

android has no /usr .  all Linux   have /bin/env it works every where

the history of /usr is originally /home folder in 60s that's why the name user .  later when /bin was full in 73 /usr/bin was created . but there was no /usr/bin/env for many years only /bin/env . old timers like me remember this . most people that remember this are still alive you can ask them  even if they are old

the common use of /usr/bin/env is a mutation like dolphins up from the water and back . bash was only in /usr/bin/bash originally and that evolved back to /usr/bin/env . the correct path is /bin/env

lack explanation it's just a mistake
