### PR TITLE
support osc 52 clip board wrapper

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -1739,7 +1739,7 @@ class DdgCmd:
                 copier_params = ['clipboard', '-i']
 
             if copier_params:
-                Popen(copier_params, stdin=PIPE, stdout=DEVNULL, stderr=DEVNULL).communicate(content)
+                Popen(copier_params, stdin=PIPE, stdout=sys.stdout, stderr=DEVNULL).communicate(content)
                 return
 
             # If native clipboard utilities are absent, try to use terminal multiplexers


### PR DESCRIPTION
open standard output for osc 52  that works every where from stdout even from remote shell

there is no need for  external apps. all terminals already have clip board access since eighties through osc standard

you can wrap it from your app

vim ~/bin/xclip
echo -ne "\e]52;c;$(base64 <&0)\a"

in termux this avoids running a JVM for every clip which is slow . termux-clipboard-set launch a JVM just to be able to call android API
