### PR TITLE
add url handler that try to find best browser . many sites are broken other wise

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,12 @@ Due to certain graphical browsers spewing messages to the console, `ddgr` suppre
 
 If you need to use a GUI browser with `BROWSER` set, use the omniprompt key `O`. `ddgr` will try to ignore text-based browsers and invoke a GUI browser. Browser logs are always suppressed with `O`.
 
+#### url handler 
+
+try the included url handler and report broken links
+
+  ddgr --url-handler url
+
 #### Colors
 
 The color configuration is similar to that of [`googler` colors](https://github.com/jarun/googler#colors). The default color string is `oCdgxy`. `ddgr` recognizes the environment variable `DDGR_COLORS`. Details are available in the `ddgr` man page.

--- a/url
+++ b/url
@@ -1,0 +1,271 @@
+#!/bin/env bash
+
+# STATIC WEB VIEWER FOR VIM CODERS that try to support all web sites in text terminal 
+
+# add broken links so we can fix them
+broken=(
+https://answers.microsoft.com/en-us/windows/forum/all/ssh-login-to-microsoft-account-linked-windows/69ea0428-5b06-401c-bb86-e45228709e0b
+https://youtrack.jetbrains.com/issue/GO-7100/Support-commenting-in-go.mod-file
+https://developer.arm.com/Architectures/Valhall
+https://android.stackexchange.com/questions/232387/
+https://www.nvidia.com/en-us/geforce/forums/legacy-products/12/182006/add-touch-screen-mapping-for-streaming-pc-games/
+https://x.com/RobbyKraft/status/971534867426144257
+https://forums.linuxmint.com/viewtopic.php?t=374298
+https://www.linuxquestions.org/questions/linux-software-2/how-to-override-xrandr-minimum-screen-size-%5Bsolved%5D-4175599058/
+)
+
+function cf() {
+  db=~/.mozilla/firefox/*.default-default/cookies.sqlite
+  # echo "select * from moz_cookies"|sqlite3 $db|ack cf_clear|  grep -o -P '(?<=cf_clearance\|).*(?=\|.stack)'
+	echo "select * from moz_cookies"|sqlite3 $db -json|ack cf_clear|ack stack |jq -r .value
+
+# db="$HOME/.config/chromium/Default/Cookies"
+	# echo "select * from cookies"|sqlite3 $db -json|ack cf_clear|ack stack |jq .
+    # SELECT name,encrypted_value FROM cookie WHERE host_key = "foobar.com";
+}
+# cf
+# exit
+
+isday() {
+read -t1 -rs -d \\ -p $'\e]11;?\e\\' bg
+bg=$(echo $bg | xxd -c 25 | cut -d/ -f2)
+if test "$(pastel format name $bg)" = white; then
+	echo true
+else
+	echo false
+fi
+}
+
+export NO_COLOR=true
+export GH_PAGER="vim - -MR"
+# if $(isday); then
+	# export GLAMOUR_STYLE=light
+# else
+	# export GLAMOUR_STYLE=dracula
+# fi
+
+test $TERM = screen-256color && export TERM=xterm-256color
+
+function ghraw() {
+	local u n p
+# g|$vim -
+u=$(echo $@ | sed s,blob,raw,)
+n=$(basename $u)
+p=~/tmp
+test -f $p/$n || wget $u -P $p
+vim $p/$n
+}
+
+
+agents=(
+Links
+Lynx
+Gecko
+Firefox
+Chrome
+"Lynx/2.8.9rel.1 libwww-FM/2.14 SSL-MM/1.4.1 OpenSSL/3.4.1"
+"Mozilla/5.0 (Android 13; Mobile; rv:133.0) Gecko/133.0 Firefox/133.0"
+"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+)
+
+# while getopts "qr" a; do
+car=false
+cro=false
+curl=false
+dump=false
+fox=false
+html=false
+imp=false
+js=false
+raw=false
+via=false
+x=false
+for a in $@; do
+	case $a in
+			-x) set -x
+				x=true
+# shift
+# shift $(($OPTIND-1))
+;;
+		-a) ag="${@: -1}"; break ;;
+		-c) curl=true ;;
+	-ca) car=true;;
+		-cf) url=${broken[3]} ;;
+	-cm) cro=true;;
+	-d) dump=true;;
+	-f) fox=true;;
+	-h) html=true;;
+	-i) imp=true;;
+	-j) js=true;;
+		-r) raw=true ;;
+		-v) via=true ;;
+			# eval "$links $u | $pager"
+		# exit;;
+	*) u+=$a 
+		# ((OPTIND++))
+			;;
+esac
+done
+
+# remove header footer if they exist 
+nohead() {
+	# echo $#
+	# exit
+	local a b c
+	a=$(links -dump $u)
+	b=$(echo "$a" | sed -nr "/$1/,\$p" 2>/dev/null)
+	if [ $# -gt 1 ]; then
+		c=$(echo "$b" | sed "/$2/q")
+	fi
+	if [ -n "$c" ]; then
+		echo "$c" | $pager
+	elif [ -n "$b" ]; then
+		echo "$b" | $pager
+	else
+		echo "$c" | $pager
+	fi
+}
+
+# pager=less
+# nohead head 
+# # nohead head foot
+# exit
+
+# parse broken pasted links
+# u="$u"|tr -d " \n|"
+if [ ! -f $u ]; then
+	u=$(echo $u|sed "s,[\ |\n],,g"|grep -Eo 'https?://[^ ]+'|sed 's/\.$//')
+fi
+host=$(echo $u | awk -F'[/:]' '{print $4}')
+path=$(echo $u | gawk -F'(https?://[^/]+|?)' '$0=$2')
+file=$(basename $u)
+agent=${agents[$(($RANDOM%3))]}
+
+if $x || $curl; then
+echo u=$u
+echo host=$host
+echo path=$path
+echo file=$file
+echo agent=$agent
+# exit
+# read -p "open page?"
+fi
+ 
+# conf
+links="links -dump"
+# pager=less
+pager="vim -MR --not-a-term -"
+# test -n "$PAGER" && pager="$PAGER"
+test "$pager" = less && pager="less -+F"
+browser="$links \"$u\" | $pager"
+
+test -n "$ag" && curl -sLA "$ag" $u | lynx -stdin -dump | less && exit
+$car && carbonyl $u && exit
+$cro && chromium-browser --enable-logging --headless --disable-gpu --dump-dom $u|lynx -stdin -dump| less && exit
+$curl && curl -sL --http2 -A "$agent" $u | lynx -stdin -dump | less && exit
+$dump && links -dump $u && exit
+$fox && browsh $u && exit
+$html && eval "links $u" && exit
+$imp && curl_chrome116 -sLA Gecko $u | lynx -stdin -dump | $pager && exit
+$js && elinks $u -dump | eval $pager;
+$raw && eval "$links $u | $pager" && exit
+$via && termux-open-url $u mark.via.gp && exit
+
+case $host in
+# cloud flare 
+x.com|askubuntu.com|*serverfault.com|*superuser.com|*stackexchange.com|stackoverflow.com)
+# carbonyl $u
+termux-open-url $u mark.via.gp
+exit
+agent='Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0'
+# echo agent=$agent
+cookie="cf_clearance=$(cf)"
+# echo cookie=$cookie
+# curl -s https://$host/cdn-cgi/trace
+# links -dump $u |  les
+	# links -dump $u | sed -nr '/Learn more about [Labs|Teams]/,$p' | sed '/Browse other questions tagged/q' | eval $pager
+# curl-impersonate \
+#  --http2-no-server-push  --alps --tls-permute-extensions --cert-compression brotli \
+# curl \
+# curl-impersonate \
+# -H 'X-Requested-With: XMLHttpRequest' \
+# -H 'sec-ch-ua-mobile: ?0' \
+# -H 'Accept-Encoding: gzip, deflate, br' \
+# --http2  --compressed --tlsv1.2  \
+# $G/opt/curl-impersonate/bin/curl \
+# curl_firefox133 \
+curl_chrome124 \
+-A "$agent" \
+-sLv -b "$cookie" \
+--referer https://$host \
+	$u | lynx -stdin -dump | less -F
+	;; 
+
+# bad pre processing 
+*ibm.com|*linux.org|linuxize.com|linux.die.net|*linuxquestions.org|*linuxmint.com|ubuntuforums.org)
+	termux-open-url $u mark.via.gp
+	exit
+	agent=Gecko
+	curl -sL --http2 -A "$agent" $u | lynx -stdin -dump | less
+	;; 
+
+# header killer
+developer.android.com) 
+	case $u in
+		*reference*) nohead 'java.lang.Object|Artifact:' 'easyToUnderstand';;
+		*) eval $browser ;;
+	esac ;;
+source.android.com) nohead 'Core Topics' 'easyToUnderstand' ;;
+cloud.google.com) nohead 'Transform with|Send feedback|Stay organized with collections' 'easyToUnderstand'  ;;
+*wikipedia.org) nohead  'From Wikipedia|Other languages'  ;; 
+
+	# custom programs 
+gist.github*.com)	gh gist view $u;;
+docs.github.com) links -dump $u | $pager;;
+github.com)
+	case $path in
+	*discussions*|*wiki*) nohead 'Jump to bottom|Additional navigation options|Select Topic Area' 	;; 
+		# eval $browser 
+	*issues*)	gh issue view --comments $u;;
+	*pull*)	gh pr view --comments $u;;
+	# file
+	*.*)
+	# curl -L $(echo $u | sed s,blob,raw,) | $pager;;
+	ghraw $u;;
+	*/*/*) gh repo view $u;;
+	# commit links etc should fall here
+	community*) links -dump $u | sed -n '/GitHub Community/,$p' 2>/dev/null | $pager ;;
+	*) eval $browser ;;
+	# GitHub Community
+	# *) ;;&
+	esac;;
+
+*gitlab.com)
+	case $u in
+	*issues*) glab issue view --comments $u;;
+	*) glab repo view $u;;
+	esac;;
+*gitlab*)
+	case $u in
+	*issues*) glab issue view $u;;
+	*) glab repo view $u;;
+	# *) eval $browser ;;
+	esac;;
+
+*reddit.com) rtv $u ;;
+
+*stackoverflow.com) socli -o $u ;;
+
+
+#  JavaScript never works 
+*cyberciti.biz) elinks $u -dump | eval $pager;;
+
+# last resort  ... 
+answers.microsoft.com|developer.arm.com|quora.com|*jetbrains.com)
+chromium-browser --enable-logging --headless --disable-gpu --dump-dom $u|lynx -stdin -dump| $pager
+# read -p "open in Firefox?" y
+# test "$y" = y && browsh $u
+;;
+
+*) eval $browser ;;
+esac


### PR DESCRIPTION
when working from the terminal many frequent search results are broken and display a bogus error message or no content or no comments or  gigantic headers before the content that takes many pages before you find the actual page content

a tool is needed to handle all broken sites and display only the page content

	ddgr --url-handler url abc

I really want help with this app . I hope it can be hosted here where others are likely to need it and improve it. since many sites are broken in text browser app

searching is just the first step then you have to read the page also which often fails

I hope this script can be improved to open all sites in the terminal

many people prefer to close the X server and unset DISPLAY and only use tmux windows  . they need a tool to read web sites . this is the solution I have not found any other tool like this I had to create it from scratch
