### PR TITLE
remove pipe from URL handler

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -117,7 +117,7 @@ def open_url(url):
 
     # Custom URL handler gets max priority
     if hasattr(open_url, 'url_handler'):
-        with Popen([open_url.url_handler, url], stdin=PIPE) as pipe:
+        with Popen([open_url.url_handler, url]) as pipe:
             pipe.communicate()
         return
 


### PR DESCRIPTION

if URL handler use vim and input is piped many strange effects can result 

vim tries to run commands

it prints various OS commands return value  to terminal output for example 10 and 11 that return terminal  colours

this will only quit it's not a full simulation 

~~~
echo|vim
Vim: Warning: Input is not from a terminal
Vim: Error reading input, exiting...
Vim: Finished.
~~~

this will cause more mayhem printing random text including  OSC 10 and 11 inside vim and if you try to select it vim close or crash

or another time print it to terminal instead and close immediately 

~~~
python -c "from subprocess import Popen, PIPE; Popen(['vim'], stdin=PIPE)"
2RR84;0;0c10;rgb:ffff/ffff/ffff11;rgb:0000/0000/0000Vim: Finished.
~~~

but you have to connect to the pipe to get full effect and even break the terminal 

~~~
python -c $'from subprocess import Popen, PIPE\nwith Popen(["vim"], stdin=PIPE) as pipe:\n pipe.communicate()'
~~~

input is still a terminal

~~~
test -t 0; echo $?
0
~~~

but it no longer repeat input so you type in blind

this will restore the terminal 

~~~
stty sane
~~~

