### PR TITLE
Exit with code 1 on HTTP errors

### DIFF
--- a/ddgr
+++ b/ddgr
@@ -838,8 +838,7 @@ class DdgConnection:
                                   expected_code=200)
         except Exception as e:
             LOGERR(e)
-            return None
-
+            sys.exit(1)
         return r
 
 


### PR DESCRIPTION
When an HTTP error occurs (e.g. 403 Forbidden), the error was logged to stderr but the process exited with code 0. This makes it impossible for wrapper scripts to detect failure: ddgr --np search && do_something would always execute do_something regardless of whether the search succeeded.
Changed return None to sys.exit(1) in the fetch_page exception handler.
Fixes #83.